### PR TITLE
Add change id and enable keybinding conf

### DIFF
--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -41,6 +41,7 @@ pub struct LogTabKeybindsConfig {
     pub edit_revset: Option<Keybind>,
     pub set_bookmark: Option<Keybind>,
     pub open_files: Option<Keybind>,
+    pub rebase: Option<Keybind>,
 
     pub push: Option<Keybind>,
     pub push_new: Option<Keybind>,

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -133,6 +133,7 @@ impl LogTabKeybinds {
             LogTabEvent::EditRevset => config.edit_revset,
             LogTabEvent::SetBookmark => config.set_bookmark,
             LogTabEvent::OpenFiles => config.open_files,
+            LogTabEvent::Rebase => config.rebase,
             event_push(false, false) => config.push,
             event_push(false, true) => config.push_new,
             event_push(true, false) => config.push_all,

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -201,8 +201,8 @@ impl<'a> LogTab<'a> {
                 self.describe_after_new = describe;
             }
             LogTabEvent::Rebase => {
-                let source_change = commander.get_current_head()?.commit_id;
-                let target_change = &self.head.commit_id;
+                let source_change = commander.get_current_head()?;
+                let target_change = &self.head;
                 self.rebase_popup = Some(RebasePopup::new(
                     source_change.clone(),
                     target_change.clone(),


### PR DESCRIPTION
Hi @peso 
Thank you for implementing rebase! 

I have been using it locally and I really liked this approach to show the CLI options and being able to select them by tying it directly (so typing 'A' selects the '-A' option). 

Anyway, this simple PR adds two things:

1. Showing the change id too, so change id and commit id are visible from the pop up
2. Adding the field to `LogTabKeybindsConfig` so keybindings for this can be configured

Happy to make further changes if you feel is necessary 👍 